### PR TITLE
Feat: set nickname when joining a server

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+export default {
+  /** The nickname to set when joining a server. */
+  nickname: 'PBDB'
+} as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,17 @@
 import discord from 'discord.js'
 import 'dotenv/config'
+import config from './config'
 
 const client = new discord.Client({
-  intents: []
+  intents: ['Guilds']
+})
+
+client.on('guildCreate', async guild => {
+  const member = guild.members.cache.get(client.user?.id ?? '')
+
+  if (typeof member === 'undefined') return
+
+  member.setNickname(config.nickname)
 })
 
 client.login(process.env['DISCORD_TOKEN'])


### PR DESCRIPTION
Although I am still considering what to call this bot, I currently intend for the username to be `Primitive Baptist Discord Bot`. However, that is quite long and renders something like `Primitive Baptist ...` in the “Member List.” For that reason, when the bot joins a server, it will attempt to set its nickname to `PBDB`. This is configurable in `src/config.ts`:

```ts
export default {
  /** The nickname to set when joining a server. */
  nickname: 'PBDB'
} as const
```